### PR TITLE
updates current and past events

### DIFF
--- a/events.html
+++ b/events.html
@@ -53,6 +53,13 @@
   <!--   Upcoming Events Section   -->
   <div class="container">
     <h3 class="header center green-text">Upcoming Events</h3>
+    <p class="flow-text">None right now! Check back soon.</p>
+  </div>
+
+
+   <!--   Past Events Section   -->
+  <div class="container">
+    <h3 class="header center green-text">Past events</h3>
     <div class="event-container">
       <h5 class="header light event-container__header">Saturday 2nd July 2016</h5>
       <h5 class="header time">
@@ -76,7 +83,7 @@
         <p class="flow-text">
             This will be a one-day workshop to introduce you to building servers with the popular Express framework.
         </p>
-        <p class="flow-text">Apply now! <a class="green-text" href="https://nodegirls.typeform.com/to/Pdpn4m">Applications</a> are open until 24th June 2016.</p>
+        <p class="flow-text">Applications closed.</p>
 
         <div class="row">
           <div class="organisers-container col m6">
@@ -111,12 +118,6 @@
         </div>
       </div>
     </div>
-  </div>
-
-
-   <!--   Past Events Section   -->
-  <div class="container">
-    <h3 class="header center green-text">Past events</h3>
     <div class="event-container">
       <h5 class="header light event-container__header">Saturday 27<sup>th</sup> February 2016</h5>
       <h5 class="header time">

--- a/index.html
+++ b/index.html
@@ -121,7 +121,7 @@
   <div class="container">
     <br>
     <br>
-    <h3 id="next-event" class="header center green-text">Next Event</h3>
+    <h3 id="next-event" class="header center green-text">Last Event</h3>
     <div class="event-container">
       <h5 class="header light event-container__header">Saturday 2<sup>nd</sup> July 2016</h5>
       <h5 class="header time">
@@ -143,7 +143,7 @@
         </div>
 
         <p class="flow-text">This will be a one-day workshop to introduce you to building servers with the popular Express framework.</p>
-        <p class="flow-text">Apply now! <a class="green-text" href="https://nodegirls.typeform.com/to/Pdpn4m">Applications</a> are open until 24th June 2016.</p>
+        <p class="flow-text">Applications closed.</p>
         <div class="row">
           <div class="organisers-container col m6">
             <a href="https://twitter.com/a_nitacz">


### PR DESCRIPTION
This pull request just adds the July workshop "next event" to "past events", and makes it date-correct for the current timeline of workshops.
