### PR TITLE
Handles when missing sponsor

### DIFF
--- a/js/all-events-template.js
+++ b/js/all-events-template.js
@@ -81,6 +81,9 @@ function generateApplicationText (event) {
 }
 
 function generateSponsors (sponsors) {
+  if (sponsors.length === 0) {
+    return '';
+  } 
   return sponsors.reduce((html, sponsor) => {
     html = html + '<a target="_blank" href="' + sponsor.link + '">\
       <img class="sponsor" src="' + sponsor.logo + '" alt="' + sponsor.name + '">\

--- a/js/next-event-template.js
+++ b/js/next-event-template.js
@@ -79,6 +79,9 @@ function generateApplicationText(event) {
 }
 
 function generateSponsors(sponsors) {
+  if (sponsors.length === 0) {
+    return "";
+  } 
   return sponsors.reduce((html, sponsor) => {
     html =
       html +

--- a/js/variables.js
+++ b/js/variables.js
@@ -5,7 +5,7 @@ var destination = document.querySelector('.events');
 // PRODUCTION URL
 // this requires the latest commit hash in the events-data repo (the merge commit from the last PR)
 // Can be the short or long version.
-var commitHash = "36bf6b0";
+var commitHash = "4104262";
 var prodUrl = "https://cdn.rawgit.com/node-girls/events-data/" + commitHash + "/events.json";
 
 // DEVELOPMENT URL


### PR DESCRIPTION
Currently the generated event HTML assumes at least one sponsor. This PR will mean it doesn't render unneeded HTML if there is no sponsor yet 