### PR TITLE
modify twitter link on home page

### DIFF
--- a/about.html
+++ b/about.html
@@ -92,16 +92,18 @@
         <hr class="why-text-container__divider" />
       </div>
 
-      <p class="flow-text">Back in 2015, a small group of coding newbies from London wondered why there were no communities for women, non-binary and trans folk
-        learning JavaScript and Node.js. So they decided to fix that.
-      <p class="flow-text">
-        Later that year, <a target="_blank" href="https://twitter.com/msmichellegar">Michelle Garrett</a>, <a target="_blank" href="https://twitter.com/minaorangina">Mina Gyimah</a> and <a target="_blank" href="https://twitter.com/claireinez">Claire Mitchell</a> created <strong>Node Girls</strong>, and the first events were held in London.
+      <p class="flow-text">Back in 2015, a small group of coding newbies from London wondered why there were no communities
+        for women, non-binary and trans folk learning JavaScript and Node.js. So they decided to fix that.
+        <p class="flow-text">
+          Later that year, <a target="_blank" href="https://twitter.com/msmichellegar">Michelle Garrett</a>, <a target="_blank"
+            href="https://twitter.com/minaorangina">Mina Gyimah</a> and <a target="_blank" href="https://twitter.com/claireinez">Claire
+            Mitchell</a> created <strong>Node Girls</strong>, and the first events were held in London.
+        </p>
+        <br />
       </p>
-      <br />
-      </p>
       <p class="flow-text">
-        Inspired by the likes of Rails Girls and Django Girls, we run free, one-day workshops, where folk can learn to code
-        in a friendly, non-intimidating environment.
+        Inspired by the likes of Rails Girls and Django Girls, we run free, one-day workshops, where folk can learn to code in a
+        friendly, non-intimidating environment.
       </p>
       <p class="flow-text">
         We put a big emphasis on making our events as accessible and inclusive as possible.
@@ -149,15 +151,15 @@
       <div class="row">
         <div class="col l6 s12 footer__contact">
           <h2 class="white-text footer__contact-title">Contact Us</h2>
-          <p class="white-text">If you have any questions, would like to become a mentor, sponsor an event or want to be involved in some way,
-            drop us a line to
+          <p class="white-text">If you have any questions, would like to become a mentor, sponsor an event or want to be
+            involved in some way, drop us a line to
             <a href="mailto:hello@nodegirls.com" class="footer__mailto">hello@nodegirls.com</a>.</p>
         </div>
 
         <div class="col l6 s12">
           <ul class="social-icons">
             <li class="social-icons__icon">
-              <a target="_blank" class="white-text" href="https://twitter.com/nodegirlslondon">
+              <a target="_blank" class="white-text" href="https://twitter.com/nodegirls">
                 <i class="fa fa-twitter fa-3x"></i>
               </a>
             </li>

--- a/chapters.html
+++ b/chapters.html
@@ -133,8 +133,8 @@
       <div class="row">
         <div class="col l6 s12 footer__contact">
           <h2 class="white-text footer__contact-title">Contact Us</h2>
-          <p class="white-text">If you have any questions, would like to become a mentor, sponsor an event or want to be involved in some way,
-            drop us a line to
+          <p class="white-text">If you have any questions, would like to become a mentor, sponsor an event or want to be
+            involved in some way, drop us a line to
             <a href="mailto:hello@nodegirls.com" class="footer__mailto">hello@nodegirls.com</a>.</p>
         </div>
 
@@ -151,7 +151,7 @@
               </a>
             </li>
             <li class="social-icons__icon">
-              <a target="_blank" class="white-text" href="mailto:hello@nodegirls.com">
+              <a class="white-text" href="mailto:hello@nodegirls.com">
                 <i class="fa fa-envelope-o fa-3x"></i>
               </a>
             </li>

--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -88,13 +88,19 @@
     <div class="main-container">
       <h1 class="header center green-text">Code of Conduct</h1>
 
-      <p class="flow-text">We are committed to providing a safe and welcoming environment at our events. Our Code of Conduct outlines our expectations of behaviour from attendees, hosts and sponsors.</p>
+      <p class="flow-text">We are committed to providing a safe and welcoming environment at our events. Our Code of Conduct
+        outlines our expectations of behaviour from attendees, hosts and sponsors.</p>
 
-      <p class="flow-text">We expect attendees to agree to abide by the <a href="https://berlincodeofconduct.org/">Berlin Code of Conduct</a>, distributed under a <a href="https://creativecommons.org/licenses/by-sa/4.0/Creative">Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)</a> license. Please read it before attending Node Girls.</p>
+      <p class="flow-text">We expect attendees to agree to abide by the <a href="https://berlincodeofconduct.org/">Berlin
+          Code of Conduct</a>, distributed under a <a href="https://creativecommons.org/licenses/by-sa/4.0/Creative">Commons
+          Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)</a> license. Please read it before attending Node Girls.</p>
 
-      <p class="flow-text">If you need to report a violation of the Code of Conduct, speak to the organisers of the event you are attending. They should be contactable via email, Twitter, and in person. More specific contact details for reporting a violation will be shared at the event.</p>
+      <p class="flow-text">If you need to report a violation of the Code of Conduct, speak to the organisers of the event
+        you are attending. They should be contactable via email, Twitter, and in person. More specific contact details for
+        reporting a violation will be shared at the event.</p>
 
-      <p class="flow-text">Organisers will respond to reports of a violation as swiftly as possible. Consequences could include an attendee being asked to leave and banned from future events.</p>
+      <p class="flow-text">Organisers will respond to reports of a violation as swiftly as possible. Consequences could include
+        an attendee being asked to leave and banned from future events.</p>
 
       <p class="flow-text">It is our number one priority that attendees feel happy and comfortable.</p>
     </div>
@@ -106,15 +112,15 @@
       <div class="row">
         <div class="col l6 s12 footer__contact">
           <h2 class="white-text footer__contact-title">Contact Us</h2>
-          <p class="white-text">If you have any questions, would like to become a mentor, sponsor an event or want to be involved in some way,
-            drop us a line to
+          <p class="white-text">If you have any questions, would like to become a mentor, sponsor an event or want to be
+            involved in some way, drop us a line to
             <a href="mailto:hello@nodegirls.com" class="footer__mailto">hello@nodegirls.com</a>.</p>
         </div>
 
         <div class="col l6 s12">
           <ul class="social-icons">
             <li class="social-icons__icon">
-              <a target="_blank" class="white-text" href="https://twitter.com/nodegirlslondon">
+              <a target="_blank" class="white-text" href="https://twitter.com/nodegirls">
                 <i class="fa fa-twitter fa-3x"></i>
               </a>
             </li>
@@ -143,7 +149,7 @@
 
   <!--  Scripts-->
   <script>
-    const mySiema = new Siema({loop: true, duration: 400})
+    const mySiema = new Siema({ loop: true, duration: 400 })
     document.querySelector('.prev-photo').addEventListener('click', () => mySiema.prev())
     document.querySelector('.next-photo').addEventListener('click', () => mySiema.next())
   </script>

--- a/events.html
+++ b/events.html
@@ -17,10 +17,10 @@
   <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css" rel="stylesheet">
   <script>
     (function (i, s, o, g, r, a, m) {
-    i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
-      (i[r].q = i[r].q || []).push(arguments)    
-}, i[r].l = 1 * new Date(); a = s.createElement(o),
-      m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
+      i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
+        (i[r].q = i[r].q || []).push(arguments)
+      }, i[r].l = 1 * new Date(); a = s.createElement(o),
+        m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
     })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
 
     ga('create', 'UA-106487866-1', 'auto');
@@ -180,8 +180,7 @@
 
               <div class="col m12 sponsors-container">
                 <a target="_blank" href="https://www.condenastinternational.com/">
-                  <img class="sponsor" src="http://www.condenastinternational.com/media/992/cni_logo_digital_ju2015.jpg"
-                    alt="Conde Nast Int"> </a>
+                  <img class="sponsor" src="http://www.condenastinternational.com/media/992/cni_logo_digital_ju2015.jpg" alt="Conde Nast Int">                  </a>
               </div>
             </div>
           </div>
@@ -866,7 +865,7 @@
         <div class="col l6 s12">
           <ul class="social-icons">
             <li class="social-icons__icon">
-              <a target="_blank" class="white-text" href="https://twitter.com/nodegirlslondon">
+              <a target="_blank" class="white-text" href="https://twitter.com/nodegirls">
                 <i class="fa fa-twitter fa-3x"></i>
               </a>
             </li>

--- a/index.html
+++ b/index.html
@@ -183,12 +183,12 @@
         <div class="col l6 s12">
           <ul class="social-icons">
             <li class="social-icons__icon">
-              <a class="white-text" href="https://twitter.com/nodegirls">
+              <a target="_blank" class="white-text" href="https://twitter.com/nodegirls">
                 <i class="fa fa-twitter fa-3x"></i>
               </a>
             </li>
             <li class="social-icons__icon">
-              <a class="white-text" href="https://github.com/node-girls/">
+              <a target="_blank" class="white-text" href="https://github.com/node-girls/">
                 <i class="fa fa-github fa-3x"></i>
               </a>
             </li>

--- a/index.html
+++ b/index.html
@@ -16,10 +16,10 @@
   <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css" rel="stylesheet">
   <script>
     (function (i, s, o, g, r, a, m) {
-    i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
-      (i[r].q = i[r].q || []).push(arguments)
-    }, i[r].l = 1 * new Date(); a = s.createElement(o),
-      m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
+      i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
+        (i[r].q = i[r].q || []).push(arguments)
+      }, i[r].l = 1 * new Date(); a = s.createElement(o),
+        m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
     })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
 
     ga('create', 'UA-106487866-1', 'auto');
@@ -139,7 +139,8 @@
               </p>
             </div>
             <div class="row center">
-              <a href="#next-event" id="download-button" class="btn-large waves-effect waves-light white join-button">Join our next workshop!</a>
+              <a href="#next-event" id="download-button" class="btn-large waves-effect waves-light white join-button">Join
+                our next workshop!</a>
             </div>
           </div>
 
@@ -174,15 +175,15 @@
       <div class="row">
         <div class="col l6 s12 footer__contact">
           <h2 class="white-text footer__contact-title">Contact Us</h2>
-          <p class="white-text">If you have any questions, would like to become a mentor, sponsor an event or want to be involved in some way,
-            drop us a line to
+          <p class="white-text">If you have any questions, would like to become a mentor, sponsor an event or want to be
+            involved in some way, drop us a line to
             <a href="mailto:hello@nodegirls.com" class="footer__mailto">hello@nodegirls.com</a>.</p>
         </div>
 
         <div class="col l6 s12">
           <ul class="social-icons">
             <li class="social-icons__icon">
-              <a class="white-text" href="https://twitter.com/nodegirlslondon">
+              <a class="white-text" href="https://twitter.com/nodegirls">
                 <i class="fa fa-twitter fa-3x"></i>
               </a>
             </li>

--- a/london.html
+++ b/london.html
@@ -131,15 +131,15 @@
       <div class="row">
         <div class="col l6 s12 footer__contact">
           <h2 class="white-text footer__contact-title">Contact Us</h2>
-          <p class="white-text">If you have any questions, would like to become a mentor, sponsor an event or want to be involved in some way,
-            drop us a line to
+          <p class="white-text">If you have any questions, would like to become a mentor, sponsor an event or want to be
+            involved in some way, drop us a line to
             <a href="mailto:london@nodegirls.com" class="footer__mailto">london@nodegirls.com</a>.</p>
         </div>
 
         <div class="col l6 s12">
           <ul class="social-icons">
             <li class="social-icons__icon">
-              <a target="_blank" class="white-text" href="https://twitter.com/nodegirlslondon">
+              <a target="_blank" class="white-text" href="https://twitter.com/nodegirls">
                 <i class="fa fa-twitter fa-3x"></i>
               </a>
             </li>

--- a/resources.html
+++ b/resources.html
@@ -88,23 +88,24 @@
           <h1 class="header center green-text">RESOURCES</h1>
           <hr class="why-text-container__divider" />
         </div>
-  
+
         <a target="_blank" href="https://node-girls.gitbook.io/beginners-javascript">
           <h2 class="header green-text">Beginners' JavaScript</h2>
         </a>
-  
-        <p class="flow-text">This is our tutorial for beginners.  If you have never written any code before, start here!</p>
+
+        <p class="flow-text">This is our tutorial for beginners. If you have never written any code before, start here!</p>
         <p class="flow-text">Find it <a target="_blank" href="https://node-girls.gitbook.io/beginners-javascript">here</a>.</p>
         <br/>
-        
+
         <a target="_blank" href="https://node-girls.gitbook.io/intro-to-express">
           <h2 class="header green-text">Introduction to Node.js and Express</h2>
         </a>
-        <p class="flow-text">This tutorial is for folk with some JavaScript knowledge who want to learn some backend skills, using the popular Express library.</p>
+        <p class="flow-text">This tutorial is for folk with some JavaScript knowledge who want to learn some backend skills,
+          using the popular Express library.</p>
         <p class="flow-text">Find it
           <a target="_blank" href="https://node-girls.gitbook.io/intro-to-express">here</a>.
         </p>
-  
+
       </div>
     </div>
 
@@ -115,15 +116,15 @@
       <div class="row">
         <div class="col l6 s12 footer__contact">
           <h2 class="white-text footer__contact-title">Contact Us</h2>
-          <p class="white-text">If you have any questions, would like to become a mentor, sponsor an event or want to be involved in some way,
-            drop us a line to
+          <p class="white-text">If you have any questions, would like to become a mentor, sponsor an event or want to be
+            involved in some way, drop us a line to
             <a href="mailto:hello@nodegirls.com" class="footer__mailto">hello@nodegirls.com</a>.</p>
         </div>
 
         <div class="col l6 s12">
           <ul class="social-icons">
             <li class="social-icons__icon">
-              <a target="_blank" class="white-text" href="https://twitter.com/nodegirlslondon">
+              <a target="_blank" class="white-text" href="https://twitter.com/nodegirls">
                 <i class="fa fa-twitter fa-3x"></i>
               </a>
             </li>


### PR DESCRIPTION
I've changed the twitter link to direct to the generic Node Girls twitter page instead of the London one to close #105. It looks like I've changed more than I did, but prettier moved some lines around. The prettier changes don't seem to have affected anything.

Also fixed a few of the links to have uniform behavior across all the pages as there were some inconsistencies. Some had target="_blank" and some didn't. I followed what seemed to be most common across the files and set all of the twitter and github links to have target="_blank" but removed it from the few mailto links that had it. 