### PR TITLE
fix paragraph tag typo causing formatting issue

### DIFF
--- a/tel-aviv.html
+++ b/tel-aviv.html
@@ -173,17 +173,17 @@
             <li class="social-icons__icon">
               <a target="_blank" class="black-text" href="https://twitter.com/nodegirlstlv">
                 <i class="fa fa-twitter fa-3x"></i>
-                <hp class="header col s12 light">
+                <p class="header col s12 light">
                   @nodegirlstlv
-                </hp>
+                </p>
               </a>
             </li>
             <li class="social-icons__icon">
               <a class="black-text" href="mailto:telaviv@nodegirls.com">
                 <i class="fa fa-envelope-o fa-3x"></i>
-                <hp class="header col s12 light">
+                <p class="header col s12 light">
                   telaviv@nodegirls.com
-                </hp>
+                </p>
               </a>
             </li>
           </ul>
@@ -201,9 +201,8 @@
       <div class="row">
         <div class="col l6 s12 footer__contact">
           <h2 class="white-text footer__contact-title">Contact Us</h2>
-          <p class="white-text">If you have any questions, would like to become a mentor, sponsor an event or want to
-            be involved in some way,
-            drop us a line to
+          <p class="white-text">If you have any questions, would like to become a mentor, sponsor an event or want to be
+            involved in some way, drop us a line to
             <a href="mailto:hello@nodegirls.com" class="footer__mailto">hello@nodegirls.com</a>.
           </p>
         </div>


### PR DESCRIPTION
While working on the twitter links, I noticed the Tel Aviv page seemed to have an odd formatting issue in the 'Contact Tel Aviv' section at the bottom (pictures below). It was a very small fix. There appeared to be a typo in the paragraph tag. 

I also noticed that the London page doesn't have this 'Contact' section at the bottom of its page. Should this be added to be consistent across all pages?

**All the other chapter pages look like this:**
![ng-stockholm](https://user-images.githubusercontent.com/31294722/47757824-1df0d280-dca0-11e8-88dc-5d157074d005.png)

**Tel-Aviv page:**
![ng-telaviv](https://user-images.githubusercontent.com/31294722/47757825-1fba9600-dca0-11e8-9bf9-b6e13d7ae267.png)

