### PR TITLE
adds contact container to bottom of London page

### DIFF
--- a/london.html
+++ b/london.html
@@ -121,6 +121,27 @@
         <!--   Past Events Section   -->
         <h2 class="header center green-text">Past events</h2>
         <div class="past-events-container"></div>
+        <div class="contact-chapter-container">
+          <h4 class="header center green-text">Contact London</h4>
+          <ul class="social-icons vertical">
+            <li class="social-icons__icon">
+              <a target="_blank" class="black-text" href="https://twitter.com/nodegirlslondon">
+                <i class="fa fa-twitter fa-3x"></i>
+                <p class="header col s12 light">
+                  @nodegirlslondon
+                </p>
+              </a>
+            </li>
+            <li class="social-icons__icon">
+              <a class="black-text" href="mailto:london@nodegirls.com">
+                <i class="fa fa-envelope-o fa-3x"></i>
+                <p class="header col s12 light">
+                  london@nodegirls.com
+                </p>
+              </a>
+            </li>
+          </ul>
+        </div>
       </div>
     </div>
 
@@ -131,8 +152,8 @@
       <div class="row">
         <div class="col l6 s12 footer__contact">
           <h2 class="white-text footer__contact-title">Contact Us</h2>
-          <p class="white-text">If you have any questions, would like to become a mentor, sponsor an event or want to be involved in some way,
-            drop us a line to
+          <p class="white-text">If you have any questions, would like to become a mentor, sponsor an event or want to be
+            involved in some way, drop us a line to
             <a href="mailto:london@nodegirls.com" class="footer__mailto">london@nodegirls.com</a>.</p>
         </div>
 


### PR DESCRIPTION
Discussed this with @minaorangina in #116. London was the only chapter page missing the bottom 'contact' section, so thought it could be added for consistency.