### PR TITLE
bugfix: shows only london events on london page

### DIFF
--- a/js/all-events-template.js
+++ b/js/all-events-template.js
@@ -31,7 +31,7 @@ function sort(data) {
 
 function filterLondon(data) {
   // filters out non-London events
-  if (document.URL.indexOf('/events') !== 0) {
+  if (document.URL.indexOf('/events') !== -1) {
     return data;
   }
   return data.filter(function(event) {

--- a/js/all-events-template.js
+++ b/js/all-events-template.js
@@ -1,5 +1,5 @@
 /*
- Only used for London events
+ Used for /london and /events
 */
 fetch(DATA_URL)
   .then(function(res) {
@@ -30,10 +30,11 @@ function sort(data) {
 }
 
 function filterLondon(data) {
-  // filters out non-London events
+  // keep all data for /events
   if (document.URL.indexOf('/events') !== -1) {
     return data;
   }
+  // filters out non-London events for /london
   return data.filter(function(event) {
     return event.city === 'london';
   });
@@ -41,13 +42,14 @@ function filterLondon(data) {
 
 function handleData(events) {
   var futureHTML;
+  var twitterHandle =
+    document.URL.indexOf('/events') !== -1 ? 'nodegirls' : 'nodegirlslondon';
   if (events.futureEvents.length === 0) {
-    futureHTML =
-      '<p class="flow-text no-events-text">\
+    futureHTML = `<p class="flow-text no-events-text">\
       More events to be announced soon.<br/>Check back here or \
-      <a target="_blank" href="https://www.twitter.com/nodegirlslondon">on Twitter</a> \
+      <a target="_blank" href="https://www.twitter.com/${twitterHandle}">on Twitter</a> \
       for updates!\
-      </p>';
+      </p>`;
   } else {
     futureHTML = events.futureEvents.reduce(generateHTML, '');
   }


### PR DESCRIPTION
There was a bug where events for all chapters were showing in the London page 😅

`all-events-template.js` used to only render a list of London events.  Now it does all events and just London ones, for use on `/london` and `/event`.

The bug was caused when I made this change.  I've also added a couple of bits i missed the first time round, like switching between the nodegirlslondon and nodegirls twitter handles.